### PR TITLE
Exclude form fields from being saved.

### DIFF
--- a/source/sayt.jquery.js
+++ b/source/sayt.jquery.js
@@ -232,11 +232,15 @@
 		}
 		
 		/*
-		 * Serialize the form data, omit excluded fields.
+		 * Serialize the form data, omit excluded fields marked with data-sayt-exlude attribute.
 		 */
 		function getFormData(theform)
 		{
-			var form_data = theform.serializeArray();
+			var theformClone = theform.clone();
+			var elementsToRemove = theformClone.find('[data-sayt-exclude]');
+			elementsToRemove.remove();
+
+			var form_data = theformClone.serializeArray();
 			return form_data;
 		}
 	};


### PR DESCRIPTION
So as suggested in #2, here is my pull request.
To exclude a field from being saved, simply add the attribute `data-sayt-exclude` to the element in the HTML code, i.e.

```
<input name="foo" data-sayt-exclude />
```
