### PR TITLE
Using correct way to unset localStorage variable

### DIFF
--- a/source/sayt.jquery.js
+++ b/source/sayt.jquery.js
@@ -87,7 +87,7 @@
         {
             $.cookie('autosaveFormCookie-' + theform.attr('id'), null, { expires: settings['days'] });
             if (typeof(Storage) !== "undefined") {
-                localStorage.setItem('autosaveFormCookie-' + theform.attr('id'), null);
+                localStorage.removeItem('autosaveFormCookie-' + theform.attr('id'));
             }
             else {
                 $.cookie('autosaveFormCookie-' + theform.attr('id'), null, { expires: settings['days'] });


### PR DESCRIPTION
Using the localStorage.removeItem() funtion to unset the cookie. With just setting it to 'null' the 'checksaveexists' function does not function as expected.
